### PR TITLE
TxBuilder.buildUnsafe(): refined logging & errors for exceptional failures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -555,8 +555,9 @@ export {
  *   script: NativeScript
  * ) => TxBuilder} attachNativeScript
  * @prop {(
- *   program: UplcProgramV1
+ *   program: UplcProgramV1 | UplcProgramV2
  * ) => TxBuilder} attachUplcProgram
+ *
  * @prop {(
  *   hash: PubKeyHash,
  *   poolId: PubKeyHashLike


### PR DESCRIPTION

 - when optimized script fails & alt script works fine, error logging is deferred from build-phase later tx.validate() phase, unless the special-case throwBuildPhaseScriptErrors option is enabled.
 - script errors are emitted as tx.UplcRuntimeError with a scriptContext prop

 - fixed builder attachUplcProgram type discrepancy