### PR TITLE
TxChainBuilder can be both a chain-builder AND its underlying client-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "test:integ": "pnpm --prefix ./test/all-pure run test",
         "test:pretty": "prettier . --check",
         "test:suite": "node --test  --experimental-test-coverage",
+        "test:debug": "node --inspect-brk --test  --experimental-test-coverage",
         "test:types": "pnpm run build:types"
     },
     "author": "Christian Schmitz",

--- a/src/chain/TxChainBuilder.js
+++ b/src/chain/TxChainBuilder.js
@@ -18,25 +18,25 @@ export function makeTxChainBuilder(source) {
 }
 
 const proxyStateUnused = {}
-const chainBuilderProxyImpl = new Proxy(proxyStateUnused, {
-    get(_proxyState, clientPropName, chainBuilder) {
-        if (clientPropName == "toString") return undefined
-        if (clientPropName == Symbol.toPrimitive) return undefined
-        if (clientPropName == Symbol.toStringTag) return undefined
+const chainBuilderProxyImpl = /* @__PURE__ */ new Proxy(proxyStateUnused, {
+        get(_proxyState, clientPropName, chainBuilder) {
+            if (clientPropName == "toString") return undefined
+            if (clientPropName == Symbol.toPrimitive) return undefined
+            if (clientPropName == Symbol.toStringTag) return undefined
 
-        const result = Reflect.get(
-            chainBuilder.source,
-            clientPropName,
-            chainBuilder.source
-        )
-        if ("function" == typeof result) {
-            return result.bind(chainBuilder.source)
+            const result = Reflect.get(
+                chainBuilder.source,
+                clientPropName,
+                chainBuilder.source
+            )
+            if ("function" == typeof result) {
+                return result.bind(chainBuilder.source)
+            }
+            return result
         }
-        return result
-    }
-})
+    })
 
-const chainBuilderProxyShim = (() => {
+const chainBuilderProxyShim = /* @__PURE__ */ (() => {
     const t = function () {}
     t.prototype = chainBuilderProxyImpl
     return t

--- a/src/chain/TxChainBuilder.js
+++ b/src/chain/TxChainBuilder.js
@@ -19,22 +19,22 @@ export function makeTxChainBuilder(source) {
 
 const proxyStateUnused = {}
 const chainBuilderProxyImpl = /* @__PURE__ */ new Proxy(proxyStateUnused, {
-        get(_proxyState, clientPropName, chainBuilder) {
-            if (clientPropName == "toString") return undefined
-            if (clientPropName == Symbol.toPrimitive) return undefined
-            if (clientPropName == Symbol.toStringTag) return undefined
+    get(_proxyState, clientPropName, chainBuilder) {
+        if (clientPropName == "toString") return undefined
+        if (clientPropName == Symbol.toPrimitive) return undefined
+        if (clientPropName == Symbol.toStringTag) return undefined
 
-            const result = Reflect.get(
-                chainBuilder.source,
-                clientPropName,
-                chainBuilder.source
-            )
-            if ("function" == typeof result) {
-                return result.bind(chainBuilder.source)
-            }
-            return result
+        const result = Reflect.get(
+            chainBuilder.source,
+            clientPropName,
+            chainBuilder.source
+        )
+        if ("function" == typeof result) {
+            return result.bind(chainBuilder.source)
         }
-    })
+        return result
+    }
+})
 
 const chainBuilderProxyShim = /* @__PURE__ */ (() => {
     const t = function () {}
@@ -52,7 +52,9 @@ class chainBuilderProxy extends chainBuilderProxyShim {}
  * @template {ReadonlyCardanoClient} SpecificSourceType
  * @implements {TxChainBuilder}
  */
-class TxChainBuilderImpl extends chainBuilderProxy {
+class TxChainBuilderImpl
+    extends /* @type {chainBuilderProxy<SpecificSourceType>} */ chainBuilderProxy
+{
     /**
      * @private
      * @readonly
@@ -86,18 +88,16 @@ class TxChainBuilderImpl extends chainBuilderProxy {
      * @type {number}
      */
     get now() {
+        // it's provided by the proxy base, but is kept here to satisfy the type-system
         return this.source.now
-        // todo: allow the base proxy to take the responsibility for this getter
-        //   ... keeping for now because with() doesn't want to believe `this` is a TxChainBuilder without it.
     }
 
     /**
      * @type {Promise<NetworkParams>}
      */
     get parameters() {
+        // it's provided by the proxy base, but is kept here to satisfy the type-system
         return this.source.parameters
-        // todo: allow the base proxy to take the responsibility for this getter
-        //   ... keeping for now because with() doesn't want to believe `this` is a TxChainBuilder without it.
     }
 
     /**
@@ -165,9 +165,8 @@ class TxChainBuilderImpl extends chainBuilderProxy {
      * @returns {boolean}
      */
     isMainnet() {
+        // it's provided by the proxy base, but is kept here to satisfy the type-system
         return this.source.isMainnet()
-        // todo: allow the base proxy to take the responsibility for this method;
-        //   ... keeping for now because with() doesn't want to believe `this` is a TxChainBuilder without it.
     }
 
     /**


### PR DESCRIPTION

 - includes syntax for satisfying typescript that all is kosher
 - doesn't yet have @PURE annotations satifactory for the purity unit test

 - includes some commentary/todos to be fixed up before proceeding
 - adds a test:debug command in package.json