### PR TITLE
support for additionalFee on a txn, separate from script fee fixups

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -544,6 +544,7 @@ export {
  * @typedef {{
  *   isMainnet: boolean
  *   refScriptRegistry?: ReadonlyRefScriptRegistry
+ *   additionalFee?: bigint
  * }} TxBuilderConfig
  */
 


### PR DESCRIPTION
 - not sure why it's true, but even with per-script budget boosts, there were some observed cases where txns were being rejected for insufficient fees; the error indicated a fee calc including & separate from scripting costs

When I tried to boost per-script budgets more, it resulted in escalation of the "needed fee" part of the error message. : /