### PR TITLE
Added CardanoTxSubmitter interface, impl by BlockfrostV0Client & Emulator

### DIFF
--- a/src/chain/TxChainBuilder.js
+++ b/src/chain/TxChainBuilder.js
@@ -129,6 +129,14 @@ class TxChainBuilderImpl
     }
 
     /**
+     * @param {TxOutputId} id
+     * @returns {Promise<boolean>}
+     */
+    async hasUtxo(id) {
+        return !!(await this.getUtxo(id))
+    }
+
+    /**
      * @param {Address} addr
      * @returns {Promise<TxInput[]>}
      */

--- a/src/clients/BlockfrostV0Client.js
+++ b/src/clients/BlockfrostV0Client.js
@@ -992,6 +992,85 @@ class BlockfrostV0ClientImpl {
     }
 
     /**
+     * checks if the error indicates the transaction having utxos not yet known to blockfrost
+     * (or if they have already been spent)
+     * @param {Error} e
+     * @returns {boolean}
+     */
+    isUnknownUtxoError(e) {
+        if (e.message.match(/:3117[,}]/)) return true
+        if (e.message.match(/unknown UTxO/)) return true
+        try {
+            const t = JSON.parse(e.message)
+            const { code, message, data, ...otherFields } = t
+            if (t.code == 3117) {
+                console.log(
+                    "isUnknownUtxoError(): Blockfrost error code 3117 AFTER parsing"
+                )
+                return true
+            }
+            console.log(
+                "unknown error structure in JSON response from Blockfrost (debugging breakpoint available)"
+            )
+            console.log("returning false for isUnknownUtxoError()")
+            debugger
+            return false
+        } catch (e) {
+            console.log(
+                "unknown error response from Blockfrost (debugging breakpoint available)"
+            )
+            console.log("returning false for isUnknownUtxoError()")
+            debugger
+            return false
+        }
+    }
+
+    /**
+     * Indicates if the error
+     * (or if they have already been spent)
+     * @param {Error} err
+     * @returns {boolean}
+     */
+    isSubmissionExpiryError(err) {
+        if (err.message.match(/:3118[,}]/)) {
+            try {
+                console.log("    --- hurray, code 3118")
+                // if ogmios error code is 3118:
+                //   - data.currentSlot shows where the chain is now
+                //    - data.validityInterval shows the detected validity interval of the tx
+                const { data, message, code, ...otherFields } = JSON.parse(
+                    err.message
+                )
+                if (code === 3118) {
+                    const { currentSlot, validityInterval } = data
+                    console.log(
+                        "not sure how to handle this (debugging breakpoint available)",
+                        {
+                            currentSlot,
+                            validityInterval
+                        }
+                    )
+                    debugger
+                    throw new Error("how to handle validity feedback?")
+                }
+                return false
+            } catch (e) {
+                console.log(
+                    "unparseable error from Blockfrost; treating as expired due to pattern match (debugging breakpoint available)"
+                )
+                debugger
+                return true
+            }
+        } else {
+            console.log(
+                "  -- unknown error format from blockfrost; treating as not-expired (debugging breakpoint available)"
+            )
+            debugger
+            return false
+        }
+    }
+
+    /**
      * @private
      * @param {BlockfrostInput} rawInput
      */

--- a/src/clients/KoiosV0Client.js
+++ b/src/clients/KoiosV0Client.js
@@ -37,19 +37,19 @@ export function makeKoiosV0Client(networkName) {
 export async function resolveKoiosV0Client(refUtxo) {
     const preprodNetwork = new KoiosV0ClientImpl("preprod")
 
-    if (await preprodNetwork.hasUtxo(refUtxo)) {
+    if (await preprodNetwork.hasUtxo(refUtxo.id)) {
         return preprodNetwork
     }
 
     const previewNetwork = new KoiosV0ClientImpl("preview")
 
-    if (await previewNetwork.hasUtxo(refUtxo)) {
+    if (await previewNetwork.hasUtxo(refUtxo.id)) {
         return previewNetwork
     }
 
     const mainnetNetwork = new KoiosV0ClientImpl("mainnet")
 
-    if (await mainnetNetwork.hasUtxo(refUtxo)) {
+    if (await mainnetNetwork.hasUtxo(refUtxo.id)) {
         return mainnetNetwork
     }
 
@@ -358,10 +358,10 @@ class KoiosV0ClientImpl {
 
     /**
      * Used by `KoiosV0.resolveUsingUtxo()`.
-     * @param {TxInput} utxo
+     * @param {TxOutputId} utxoId
      * @returns {Promise<boolean>}
      */
-    async hasUtxo(utxo) {
+    async hasUtxo(utxoId) {
         const url = `${this.rootUrl}/api/v0/tx_info`
 
         const response = await fetch(url, {
@@ -371,7 +371,7 @@ class KoiosV0ClientImpl {
                 "content-type": "application/json"
             },
             body: JSON.stringify({
-                _tx_hashes: [utxo.id.txId.toHex()]
+                _tx_hashes: [utxoId.txId.toHex()]
             })
         })
 

--- a/src/clients/ReadonlyCardanoMultiClient.js
+++ b/src/clients/ReadonlyCardanoMultiClient.js
@@ -1,6 +1,6 @@
 /**
  * @import { Address, AssetClass, NetworkParams, Tx, TxId, TxInput, TxOutputId } from "@helios-lang/ledger"
- * @import { CardanoTxSubmitter, ReadonlyCardanoClient, TxSummary } from "../index.js"
+ * @import { ReadonlyCardanoClient, TxSummary } from "../index.js"
  */
 
 /**
@@ -167,14 +167,14 @@ class ReadonlyCardanoMultiClientImpl {
 }
 
 /**
- * @template {ReadonlyCardanoClient | CardanoTxSubmitter } C
+ * @template {ReadonlyCardanoClient} C
  * @template T
  * @param {C[]} clients
  * @param {(client: C) => Promise<T>} callback
  * @param {string} msg
  * @returns {Promise<T>}
  */
-export async function tryClientsAsync(clients, callback, msg) {
+async function tryClientsAsync(clients, callback, msg) {
     /**
      * @type {Error[]}
      */

--- a/src/clients/ReadonlyCardanoMultiClient.js
+++ b/src/clients/ReadonlyCardanoMultiClient.js
@@ -1,6 +1,6 @@
 /**
  * @import { Address, AssetClass, NetworkParams, Tx, TxId, TxInput, TxOutputId } from "@helios-lang/ledger"
- * @import { ReadonlyCardanoClient, TxSummary } from "../index.js"
+ * @import { CardanoTxSubmitter, ReadonlyCardanoClient, TxSummary } from "../index.js"
  */
 
 /**
@@ -167,14 +167,14 @@ class ReadonlyCardanoMultiClientImpl {
 }
 
 /**
- * @template {ReadonlyCardanoClient} C
+ * @template {ReadonlyCardanoClient | CardanoTxSubmitter } C
  * @template T
  * @param {C[]} clients
  * @param {(client: C) => Promise<T>} callback
  * @param {string} msg
  * @returns {Promise<T>}
  */
-async function tryClientsAsync(clients, callback, msg) {
+export async function tryClientsAsync(clients, callback, msg) {
     /**
      * @type {Error[]}
      */

--- a/src/emulator/Emulator.js
+++ b/src/emulator/Emulator.js
@@ -197,6 +197,20 @@ class EmulatorImpl {
     }
 
     /**
+     * @param {TxId} id
+     * @returns {Promise<Tx>}
+     */
+    async getTx(id) {
+        const found = this.mempool.find((tx) => tx.id() === id)
+
+        if (!found) {
+            throw new Error(`Tx ${id.toString()} not found`)
+        }
+
+        return /** @type {any} */ (found)
+    }
+
+    /**
      * Throws an error if the UTxO isn't found
      * @param {TxOutputId} id
      * @returns {Promise<TxInput>}
@@ -294,6 +308,26 @@ class EmulatorImpl {
         this.mempool.push(makeEmulatorRegularTx(tx))
 
         return tx.id()
+    }
+
+    /**
+     * @param {Error} e
+     * @returns {boolean}
+     */
+    isUnknownUtxoError(e) {
+        return (
+            e.message.includes("some inputs don't exist") ||
+            e.message.includes("some ref inputs don't exist") ||
+            e.message.includes("input already consumed before")
+        )
+    }
+
+    /**
+     * @param {Error} e
+     * @returns {boolean}
+     */
+    isSubmissionExpiryError(e) {
+        return e.message.includes("slot out of range")
     }
 
     /**

--- a/src/emulator/Emulator.js
+++ b/src/emulator/Emulator.js
@@ -213,6 +213,18 @@ class EmulatorImpl {
         }
     }
 
+    /*
+     * @param {TxOutputId} id
+     * @returns {Promise<TxInput>}
+     */
+    async hasUtxo(id) {
+        try {
+            return !!(await this.getUtxo(id))
+        } catch (e) {
+            return false
+        }
+    }
+
     /**
      * @param {Address} address
      * @returns {Promise<TxInput[]>}

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,11 @@ export {
  *
  * @prop {(tx: Tx) => Promise<TxId>} submitTx
  * Submits a transaction to the blockchain.
+ * @prop {(e: Error) => boolean} isUnknownUtxoError
+ * Checks a submit error to see if it indicates the presence of a UTxO not yet found.
+ *
+ * @prop {(e: Error) => boolean} isSubmissionExpiryError
+ * Checks a submit error to see if it indicates that the transaction is too old to be accepted.
  */
 
 /**
@@ -302,6 +307,9 @@ export {
  * @prop {(address: Address) => Promise<TxInput[]>} getUtxos
  * Returns a complete list of UTxOs at a given address.
  *
+ * @prop {(utxoId: TxOutputId) => Promise<boolean>} hasUtxo;
+ * indicates whether the underlying network is known to have the UTxO
+ *
  * @prop {(address: Address, assetClass: AssetClass) => Promise<TxInput[]>} [getUtxosWithAssetClass]
  * Optionally more efficient method to get a complete list of UTxOs at a given address, filtered to contain a given AssetClass
  *
@@ -341,6 +349,18 @@ export {
  */
 
 /**
+ * @typedef {Pick<
+ *      CardanoClient,
+ *      "isMainnet" | "submitTx" | "getTx" | "hasUtxo"
+ * > & {
+ *   isUnknownUtxoError: (e: Error) => boolean
+ *   isSubmissionExpiryError (e: Error): boolean
+ * }} CardanoTxSubmitter
+ * Conforms to a minimal subset of the Cardano network-client type
+ * needed to submit transactions and get feedback on the submission status.
+ */
+
+/**
  * @typedef {object} Emulator
  * A simple emulated Network.
  * This can be used to do integration tests of whole dApps.
@@ -375,6 +395,9 @@ export {
  * Throws an error if the UTxO isn't found
  *
  * @prop {(addr: Address) => Promise<TxInput[]>} getUtxos
+ *
+ * @prop {(utxoId: TxOutputId) => Promise<boolean>} hasUtxo;
+ * true if the utxo is in the known set
  *
  * @prop {(utxo: TxInput) => boolean} isConsumed
  *
@@ -432,7 +455,7 @@ export {
  * @prop {(id: TxOutputId) => Promise<TxInput>} getUtxo
  * @prop {(addr: Address) => Promise<TxInput[]>} getUtxos
  * @prop {() => boolean} isMainnet
- * @prop {(utxo: TxInput) => Promise<boolean>} hasUtxo
+ * @prop {(utxoId: TxOutputId) => Promise<boolean>} hasUtxo
  * @prop {(tx: Tx) => Promise<TxId>} submitTx
  */
 
@@ -848,6 +871,7 @@ export {
  * @prop {() => TxChain} build
  * @prop {(id: TxOutputId) => Promise<TxInput>} getUtxo
  * @prop {(addr: Address) => Promise<TxInput[]>} getUtxos
+ * @prop {(utxoId: TxOutputId) => Promise<boolean>} hasUtxo;
  * @prop {(tx: Tx) => Promise<TxId>} submitTx
  * @prop {() => boolean} isMainnet
  */


### PR DESCRIPTION
The interface contains a subset of methods to support submitting and confirming txns

This still has a couple sketchy bits - feedback welcome, as I think you've been coping with some of the same issues

The main thing here is abstraction of "what does this error mean" for practical/actionable purposes of automating reliable submission, particularly in context of having a chain of txns with later txns consuming recently-generated ones.  

Notably, I have observed anecdotally a kind of message when trying to resubmit a tx that the node already knows about, which falls through to the "permanent fail" branch.  I haven't captured that specific error message yet for trapping its key identifying characteristics (it dumps some kind of haskell expr, it seems), so I'll hope to get that nailed down and tidy up the uncertainties before proceeding here.