### PR TITLE
fix(BlockfrostV0Client): use cost_models_raw for canonical order

### DIFF
--- a/src/clients/BlockfrostV0Client.js
+++ b/src/clients/BlockfrostV0Client.js
@@ -41,6 +41,11 @@ import { SubmissionExpiryError, SubmissionUtxoError } from "./errors.js"
  *       PlutusV2: Record<string, number>
  *       PlutusV3: number[]
  *   }
+ *   cost_models_raw?: {
+ *       PlutusV1?: number[]
+ *       PlutusV2?: number[]
+ *       PlutusV3?: number[]
+ *   }
  *   e_max: number
  *   extra_entropy: null
  *   key_deposit: LargeNumber
@@ -383,14 +388,11 @@ class BlockfrostV0ClientImpl {
                 ).then((r) => r.json())
             )
 
-            /**
-             * @param {Record<string, number>} obj
-             * @returns {number[]}
-             */
-            const convertOldCostModels = (obj) => {
-                const keys = Object.keys(obj).sort()
-
-                return keys.map((k) => obj[k])
+            const rawCostModels = bfParams.cost_models_raw
+            if (!rawCostModels) {
+                throw new Error(
+                    "Blockfrost response missing cost_models_raw"
+                )
             }
 
             /**
@@ -399,13 +401,9 @@ class BlockfrostV0ClientImpl {
             const params = {
                 secondsPerSlot: 1,
                 collateralPercentage: bfParams.collateral_percent,
-                costModelParamsV1: convertOldCostModels(
-                    bfParams.cost_models.PlutusV1
-                ),
-                costModelParamsV2: convertOldCostModels(
-                    bfParams.cost_models.PlutusV2
-                ),
-                costModelParamsV3: bfParams.cost_models?.PlutusV3 ?? [],
+                costModelParamsV1: rawCostModels.PlutusV1 ?? [],
+                costModelParamsV2: rawCostModels.PlutusV2 ?? [],
+                costModelParamsV3: rawCostModels.PlutusV3 ?? [],
                 exCpuFeePerUnit: bfParams.price_step,
                 exMemFeePerUnit: bfParams.price_mem,
                 maxCollateralInputs: 3,


### PR DESCRIPTION
cost_models (named) is not safe to alphabetize: post-Babbage params (`andByteString`, `bls12_381_`\*, `cekConstrCost`, `cekCaseCost`, etc) are appended by the ledger in insertion order, not sort order. Using the sorted array as the language_views input mismatches the ledger and fails as ScriptIntegrityHashMismatch on V2 script txns.

Uses blockfrost's `cost_models_raw` (canonical-order array) instead; throws if absent.